### PR TITLE
Fix n+1 queries scores feed performance issue

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.all.includes(:user).order(played_at: :desc, id: :desc)
       serialized_scores = scores.map(&:serialize)
 
       response = {


### PR DESCRIPTION
Fixes: [scores feed performance](https://github.com/GeorgeMarcus/golfr_backend/issues/1)

**Changes**

Until now, the Lazy loading used when getting the scores feed was causing extra queries to be executed [N+1 problem](https://blog.appsignal.com/2018/04/24/active-record-performance-the-n-1-queries-antipattern.html)

**Before**

Queries executed with lazy loading:
<img width="851" alt="Screenshot 2022-08-01 at 12 37 03" src="https://user-images.githubusercontent.com/108520650/182130155-42b11eb5-b47b-47e1-97d3-f6abf85db321.png">

**After**

Queries executed with eager loading:
<img width="903" alt="Screenshot 2022-08-01 at 12 36 02" src="https://user-images.githubusercontent.com/108520650/182130190-37ad4ebb-a0e3-40f2-9199-1e70d56acbb5.png">
