### PR TITLE
Add route for golfers scores page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,6 +230,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-21
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,7 +230,6 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
-  x86_64-darwin-21
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -48,4 +48,3 @@ module Api
     end
   end
 end
-

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -2,6 +2,7 @@ module Api
   # Controller that handles authorization and user data fetching
   class UsersController < ApplicationController
     include Devise::Controllers::Helpers
+    before_action :logged_in!, only: :show
 
     def login
       user = User.find_by('lower(email) = ?', params[:email])
@@ -26,5 +27,25 @@ module Api
         }
       }.to_json
     end
+
+    def show
+      user = User.find_by(id: params[:id])
+
+      if user
+        render json: {
+          user: {
+            name: user.name,
+            scores: user.scores
+          }
+        }
+      else
+        render json: {
+          errors: [
+            'Invalid user id: ' + params[:id]
+          ]
+        }, status: :not_found
+      end
+    end
   end
 end
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   namespace :api do
     post 'login', to: 'users#login'
     get 'feed', to: 'scores#user_feed'
-    get 'user/:id', to: 'users#show'
+    get 'user/scores/:id', to: 'users#show'
     resources :scores, only: %i[create destroy]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   namespace :api do
     post 'login', to: 'users#login'
     get 'feed', to: 'scores#user_feed'
-    get 'user/scores/:id', to: 'users#show'
+    get 'users/:id', to: 'users#show'
     resources :scores, only: %i[create destroy]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   namespace :api do
     post 'login', to: 'users#login'
     get 'feed', to: 'scores#user_feed'
+    get 'user/:id', to: 'users#show'
     resources :scores, only: %i[create destroy]
   end
 end


### PR DESCRIPTION
Fixes: [Adding a golfer page](https://github.com/GeorgeMarcus/golfr_frontend/issues/1)

**Changes**

Added /api/users/:id route, returning all of the scores posted by the :id user. 

**Before**

The endpoint couldn't be used:
<img width="564" alt="Screenshot 2022-08-03 at 17 09 59" src="https://user-images.githubusercontent.com/108520650/182630540-5ed65cdc-22a9-4fb2-baf1-323a254b29f6.png">


**After**
case valid :id : It returns all of the scores posted by the :id user
<img width="564" alt="Screenshot 2022-08-03 at 17 09 59" src="https://user-images.githubusercontent.com/108520650/182630428-b0eb2c40-d291-41e3-9f09-26efbf460504.png">



case invalid :id : Error 
<img width="596" alt="Screenshot 2022-08-03 at 17 10 03" src="https://user-images.githubusercontent.com/108520650/182630384-bb8a07d0-0b0c-429b-83fd-3e60c78a4527.png">


