### PR TITLE
Limit the scores number shown on the feed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,6 +230,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-21
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,7 +230,6 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
-  x86_64-darwin-21
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)

--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.all.order(played_at: :desc, id: :desc).limit(25)
       serialized_scores = scores.map(&:serialize)
 
       response = {

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,11 +29,11 @@ User.create!(
 rng = Random.new
 now = Time.zone.today
 User.all.each do |user|
-  5.times do |i|
+  20.times do |i|
     Score.create!(
       user: user,
       total_score: rng.rand(66..99),
-      played_at: now - 5.days + i.days
+      played_at: now - 20.days + i.days
     )
   end
 end

--- a/spec/controllers/api/scores_controller_spec.rb
+++ b/spec/controllers/api/scores_controller_spec.rb
@@ -26,6 +26,21 @@ describe Api::ScoresController, type: :request do
       expect(scores[1]['total_score']).to eq 68
       expect(scores[2]['total_score']).to eq 79
     end
+
+    it 'should show a limited number of scores in feed' do
+      # extra setup to have more than 25 scores posted
+      30.times do
+        create(:score, user: @user1, total_score: 79, played_at: '2021-05-20')
+      end
+
+      get api_feed_path
+
+      expect(response).to have_http_status(:ok)
+      response_hash = JSON.parse(response.body)
+      scores = response_hash['scores']
+
+      expect(scores.size).to be <= 25
+    end
   end
 
   describe 'POST create' do


### PR DESCRIPTION
Fixes:[ Scores number feed limit](https://github.com/GeorgeMarcus/golfr_backend/issues/21)

**Changes**

Added a limit in scores_controller, returning a max of 25 scores.

**Before**
All of the scores were shown in the UI.
The /api/feed response returned all of the scores (529 reps lines):
<img width="521" alt="Screenshot 2022-08-03 at 11 31 13" src="https://user-images.githubusercontent.com/108520650/182562536-b1007bea-4c29-44b2-be98-c0a25623c1dd.png">

The test verifying the limit was not passing:
<img width="976" alt="Screenshot 2022-08-03 at 11 28 15" src="https://user-images.githubusercontent.com/108520650/182561738-4c1ba747-7fbe-4f21-8f2c-47dd9cba84e4.png">

**After**
There is a maximum of 25 scores shown in the UI feed
The /api/feed response returned only 25 scores (179 reps lines):
<img width="433" alt="Screenshot 2022-08-03 at 11 32 39" src="https://user-images.githubusercontent.com/108520650/182562720-480dd14a-7c55-4757-99e7-2180dae2de22.png">


The test verifying the limit was is passing:
<img width="473" alt="Screenshot 2022-08-03 at 11 29 15" src="https://user-images.githubusercontent.com/108520650/182561939-3aa135c6-7cbf-40fc-a1db-d071df23e747.png">

